### PR TITLE
Add support for pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 .byebug_history
+.idea

--- a/lib/graphql/query_resolver.rb
+++ b/lib/graphql/query_resolver.rb
@@ -22,12 +22,10 @@ module GraphQL
       to_load
     end
 
-    def self.map_dependencies(class_name, ast_node)
-      dependencies = {}
+    def self.map_dependencies(class_name, ast_node, dependencies={})
       ast_node.selections.each do |selection|
         name = selection.name
-
-        if class_name.reflections.with_indifferent_access[selection.name].present?
+        if class_name.reflections.with_indifferent_access[name].present?
           begin
             current_class_name = selection.name.singularize.classify.constantize
             dependencies[name] = map_dependencies(current_class_name, selection)
@@ -35,9 +33,11 @@ module GraphQL
             selection_name = class_name.reflections.with_indifferent_access[selection.name].options[:class_name]
             current_class_name = selection_name.singularize.classify.constantize
             dependencies[selection.name.to_sym] = map_dependencies(current_class_name, selection)
-
             next
           end
+
+        elsif selection.selections.present?
+            map_dependencies(class_name, selection, dependencies)
         end
       end
 

--- a/spec/graphql/query_resolver_spec.rb
+++ b/spec/graphql/query_resolver_spec.rb
@@ -98,4 +98,32 @@ describe GraphQL::QueryResolver do
 
     expect(queries.size).to eq(2)
   end
+
+  it 'works with pagination' do
+    query = %{
+      query {
+        vendors(first: 5) {
+          edges {
+            node {
+              id
+              name
+              ingredients {
+                name
+                quantity
+              }
+            }
+            cursor
+          }
+          pageInfo {
+            hasNextPage
+          }
+        }
+      }
+    }
+    queries = track_queries do
+      GQL.query(query)
+    end
+
+    expect(queries.size).to eq(2)
+  end
 end

--- a/spec/support/graphql_schema.rb
+++ b/spec/support/graphql_schema.rb
@@ -60,6 +60,14 @@ VendorType = GraphQL::ObjectType.define do
 
   field :id, types.ID
   field :name, types.String
+
+  field :ingredients do
+    type types[IngredientType]
+
+    resolve -> (obj, args, ctx) {
+      obj.ingredients
+    }
+  end
 end
 
 IngredientType = GraphQL::ObjectType.define do
@@ -94,6 +102,14 @@ QueryRoot = GraphQL::ObjectType.define do
 
       GraphQL::QueryResolver::run(Restaurant, ctx, RestaurantType) do
         Restaurant.find(id)
+      end
+    }
+  end
+
+  connection :vendors, VendorType.connection_type, max_page_size: 50 do
+    resolve -> (obj, args, ctx) {
+      GraphQL::QueryResolver::run(Vendor, ctx, VendorType) do
+        Vendor.all.to_a
       end
     }
   end


### PR DESCRIPTION
GraphQL spec requires pagination query, which ruby-graphql supports, to be in form of:

```
    query {
        vendors(first: 5) {
          edges {
            node {
              id
              name
              ingredients {
                name
                quantity
              }
            }
            cursor
          }
          pageInfo {
            endCursor
            hasNextPage
            hasPreviousPage
            startCursor
          }
        }
      }
```

This fixes that issue, now this commit will remove the N+1 query that was previously present from this GraphQL query